### PR TITLE
Try to prevent outdated warning as formula

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
           mkdir .brew-install
 
           to_install=$(brew install $flags --dry-run --quiet -- $packages \
-            | { grep --invert-match '==>' || true; })
+            | { grep --invert-match --extended-regexp --regexp='==>|installed but outdated' || true; } )
 
           required="$(head -1 <<< "$to_install")"
           dependencies="$(tail -n+2 <<< "$to_install")"


### PR DESCRIPTION
As I said in my last comment, I'm not sure this will always apply, but it fixes #4 for me. I think it will most likely work because the reason for that warning is the fact that package was requested in the first place.