### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/brew-install/security/code-scanning/1](https://github.com/gerlero/brew-install/security/code-scanning/1)

To fix the problem, we should add a `permissions:` block to `.github/workflows/ci.yml`. The ideal approach is to add it at the top level (root of the workflow), directly below the workflow name, so it applies to all jobs unless overridden. The minimal starting point is `contents: read`, which covers the needs of most workflows that only need to check out code and do not push or publish. None of the steps shown perform privileged write operations (such as creating releases or publishing changes), so `contents: read` is sufficient and recommended. This edit should insert:

```yaml
permissions:
  contents: read
```

after the `name: CI` line, shifting subsequent lines down. No imports, method definitions, or additional permissions for specific scopes are needed at this time.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
